### PR TITLE
feat: Add move cursor and extend selection to word boundary

### DIFF
--- a/lib/src/_code_line.dart
+++ b/lib/src/_code_line.dart
@@ -479,12 +479,116 @@ class _CodeLineEditingControllerImpl extends ValueNotifier<CodeLineEditingValue>
 
   @override
   void moveCursorToWordBoundaryForward() {
-    // TODO
+    if (selection.extentOffset == 0) {
+      final int newIndex = selection.extentIndex - 1;
+
+      if (newIndex < 0) {
+        return;
+      }
+
+      selection = CodeLineSelection.collapsed(
+        index: newIndex,
+        offset: codeLines[newIndex].length,
+      );
+      makeCursorVisible();
+    }
+
+    final String current = extentLine.text;
+
+    if (current.isEmpty) {
+      return;
+    }
+
+    int offset = selection.extentOffset - 1;
+
+    while (offset > 0) {
+      if (current.codeUnitAt(offset) == _kUnitCodeWhitespace) {
+        offset--;
+      } else {
+        break;
+      }
+    }
+
+    final int codeUnit = current.codeUnitAt(offset);
+    bool isBeforeAlphanumeric = _isAlphanumeric(codeUnit);
+    int i = offset - 1;
+
+    while (i > 0) {
+      bool isCurrentAlphanumeric = _isAlphanumeric(current.codeUnitAt(i));
+
+      if (isBeforeAlphanumeric != isCurrentAlphanumeric) {
+        break;
+      }
+
+      isBeforeAlphanumeric = isCurrentAlphanumeric;
+      i--;
+    }
+
+    if (i <= 0) {
+      i = 0;
+    } else {
+      i++;
+    }
+
+    selection = CodeLineSelection.collapsed(
+      index: selection.extentIndex,
+      offset: i,
+    );
+    makeCursorVisible();
   }
 
   @override
   void moveCursorToWordBoundaryBackward() {
-    // TODO
+    if (selection.extentOffset == extentLine.text.length) {
+      final int newIndex = selection.extentIndex + 1;
+
+      if (newIndex >= codeLines.length) {
+        return;
+      }
+
+      selection = CodeLineSelection.collapsed(
+        index: newIndex,
+        offset: 0,
+      );
+      makeCursorVisible();
+    }
+
+    final String current = extentLine.text;
+
+    if (current.isEmpty) {
+      return;
+    }
+
+    int offset = selection.extentOffset;
+
+    while (offset < current.length) {
+      if (current.codeUnitAt(offset) == _kUnitCodeWhitespace) {
+        offset++;
+      } else {
+        break;
+      }
+    }
+
+    final int codeUnit = current.codeUnitAt(offset);
+    bool isBeforeAlphanumeric = _isAlphanumeric(codeUnit);
+    int i = offset + 1;
+
+    while (i < current.length) {
+      bool isCurrentAlphanumeric = _isAlphanumeric(current.codeUnitAt(i));
+
+      if (isBeforeAlphanumeric != isCurrentAlphanumeric) {
+        break;
+      }
+
+      isBeforeAlphanumeric = isCurrentAlphanumeric;
+      i++;
+    }
+
+    selection = CodeLineSelection.collapsed(
+      index: selection.extentIndex,
+      offset: i,
+    );
+    makeCursorVisible();
   }
 
   @override
@@ -609,6 +713,120 @@ class _CodeLineEditingControllerImpl extends ValueNotifier<CodeLineEditingValue>
     selection = selection.copyWith(
       extentIndex: codeLines.length - 1,
       extentOffset: codeLines.last.length
+    );
+    makeCursorVisible();
+  }
+
+  @override
+  void extendSelectionToWordBoundaryForward() {
+    if (selection.extentOffset == 0) {
+      final int newIndex = selection.extentIndex - 1;
+
+      if (newIndex < 0) {
+        return;
+      }
+
+      selection = selection.copyWith(
+        extentIndex: newIndex,
+        extentOffset: codeLines[newIndex].length,
+      );
+      makeCursorVisible();
+    }
+
+    final String current = extentLine.text;
+
+    if (current.isEmpty) {
+      return;
+    }
+
+    int offset = selection.extentOffset - 1;
+
+    while (offset > 0) {
+      if (current.codeUnitAt(offset) == _kUnitCodeWhitespace) {
+        offset--;
+      } else {
+        break;
+      }
+    }
+
+    final int codeUnit = current.codeUnitAt(offset);
+    bool isBeforeAlphanumeric = _isAlphanumeric(codeUnit);
+    int i = offset - 1;
+
+    while (i > 0) {
+      bool isCurrentAlphanumeric = _isAlphanumeric(current.codeUnitAt(i));
+
+      if (isBeforeAlphanumeric != isCurrentAlphanumeric) {
+        break;
+      }
+
+      isBeforeAlphanumeric = isCurrentAlphanumeric;
+      i--;
+    }
+
+    if (i <= 0) {
+      i = 0;
+    } else {
+      i++;
+    }
+
+    selection = selection.copyWith(
+      extentIndex: selection.extentIndex,
+      extentOffset: i,
+    );
+    makeCursorVisible();
+  }
+
+  @override
+  void extendSelectionToWordBoundaryBackward() {
+    if (selection.extentOffset == extentLine.text.length) {
+      final int newIndex = selection.extentIndex + 1;
+
+      if (newIndex >= codeLines.length) {
+        return;
+      }
+
+      selection = selection.copyWith(
+        extentIndex: newIndex,
+        extentOffset: 0,
+      );
+      makeCursorVisible();
+    }
+
+    final String current = extentLine.text;
+
+    if (current.isEmpty) {
+      return;
+    }
+
+    int offset = selection.extentOffset;
+
+    while (offset < current.length) {
+      if (current.codeUnitAt(offset) == _kUnitCodeWhitespace) {
+        offset++;
+      } else {
+        break;
+      }
+    }
+
+    final int codeUnit = current.codeUnitAt(offset);
+    bool isBeforeAlphanumeric = _isAlphanumeric(codeUnit);
+    int i = offset + 1;
+
+    while (i < current.length) {
+      bool isCurrentAlphanumeric = _isAlphanumeric(current.codeUnitAt(i));
+
+      if (isBeforeAlphanumeric != isCurrentAlphanumeric) {
+        break;
+      }
+
+      isBeforeAlphanumeric = isCurrentAlphanumeric;
+      i++;
+    }
+
+    selection = selection.copyWith(
+      extentIndex: selection.extentIndex,
+      extentOffset: i,
     );
     makeCursorVisible();
   }
@@ -865,6 +1083,12 @@ class _CodeLineEditingControllerImpl extends ValueNotifier<CodeLineEditingValue>
   }
 
   _CodeFieldRender? get _render => _editorKey?.currentContext?.findRenderObject() as _CodeFieldRender?;
+
+  bool _isAlphanumeric(int codeUnit) {
+    return (codeUnit <= 57 && codeUnit >= 48) ||
+        (codeUnit <= 90 && codeUnit >= 65) ||
+        (codeUnit <= 122 && codeUnit >= 97);
+  }
 
   void _moveSelectionLinesUp() {
     if (selection.startIndex == 0) {
@@ -1882,6 +2106,16 @@ class _CodeLineEditingControllerDelegate implements CodeLineEditingController {
   @override
   void extendSelectionToPageStart() {
     _delegate.extendSelectionToPageStart();
+  }
+
+  @override
+  void extendSelectionToWordBoundaryBackward() {
+    _delegate.extendSelectionToWordBoundaryBackward();
+  }
+
+  @override
+  void extendSelectionToWordBoundaryForward() {
+    _delegate.extendSelectionToWordBoundaryForward();
   }
 
   @override

--- a/lib/src/_code_shortcuts.dart
+++ b/lib/src/_code_shortcuts.dart
@@ -234,6 +234,14 @@ class _CodeShortcutActions extends StatelessWidget {
         }
         break;
       }
+      case CodeShortcutSelectionExtendWordBoundaryIntent: {
+        if ((intent as CodeShortcutSelectionExtendWordBoundaryIntent).forward) {
+          editingController.extendSelectionToWordBoundaryForward();
+        } else {
+          editingController.extendSelectionToWordBoundaryBackward();
+        }
+        break;
+      }
       case CodeShortcutDeleteIntent: {
         if ((intent as CodeShortcutDeleteIntent).forward) {
           editingController.deleteForward();

--- a/lib/src/code_line.dart
+++ b/lib/src/code_line.dart
@@ -223,10 +223,10 @@ abstract class CodeLineEditingController extends ValueNotifier<CodeLineEditingVa
   /// TODO
   void moveCursorToPageDown();
 
-  /// TODO
+  /// Move the cursor to the start of the word.
   void moveCursorToWordBoundaryForward();
 
-  /// TODO
+  /// Move the cursor to the end of the word.
   void moveCursorToWordBoundaryBackward();
 
   /// Extend the selection to a direction.
@@ -243,6 +243,12 @@ abstract class CodeLineEditingController extends ValueNotifier<CodeLineEditingVa
 
   /// Extend the selection to the end of document.
   void extendSelectionToPageEnd();
+
+  /// Extend the selection to the start of the word.
+  void extendSelectionToWordBoundaryForward();
+
+  /// Extend the selection to the end of the word.
+  void extendSelectionToWordBoundaryBackward();
 
   /// Delete the selected lines.
   void deleteSelectionLines([bool keepExtentOffset = true]);

--- a/lib/src/code_shortcuts.dart
+++ b/lib/src/code_shortcuts.dart
@@ -33,6 +33,8 @@ enum CodeShortcutType {
   selectionExtendLineEnd,
   selectionExtendPageStart,
   selectionExtendPageEnd,
+  selectionExtendWordBoundaryForward,
+  selectionExtendWordBoundaryBackward,
   indent,
   outdent,
   newLine,
@@ -161,6 +163,11 @@ class CodeShortcutSelectionExtendPageEdgeIntent extends Intent {
   const CodeShortcutSelectionExtendPageEdgeIntent(this.forward);
 }
 
+class CodeShortcutSelectionExtendWordBoundaryIntent extends Intent {
+  final bool forward;
+  const CodeShortcutSelectionExtendWordBoundaryIntent(this.forward);
+}
+
 class CodeShortcutDeleteIntent extends CodeShortcutEditableIntent {
   final bool forward;
   const CodeShortcutDeleteIntent(this.forward);
@@ -231,6 +238,8 @@ const Map<CodeShortcutType, Intent> kCodeShortcutIntents = {
   CodeShortcutType.selectionExtendLineEnd: CodeShortcutSelectionExtendLineEdgeIntent(true),
   CodeShortcutType.selectionExtendPageStart: CodeShortcutSelectionExtendPageEdgeIntent(false),
   CodeShortcutType.selectionExtendPageEnd: CodeShortcutSelectionExtendPageEdgeIntent(true),
+  CodeShortcutType.selectionExtendWordBoundaryForward: CodeShortcutSelectionExtendWordBoundaryIntent(true),
+  CodeShortcutType.selectionExtendWordBoundaryBackward: CodeShortcutSelectionExtendWordBoundaryIntent(false),
   CodeShortcutType.indent: CodeShortcutIndentIntent(),
   CodeShortcutType.outdent: CodeShortcutOutdentIntent(),
   CodeShortcutType.newLine: CodeShortcutNewLineIntent(),
@@ -353,6 +362,12 @@ const Map<CodeShortcutType, List<ShortcutActivator>> _kDefaultMacCodeShortcutsAc
   CodeShortcutType.selectionExtendLineEnd: [
     SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, meta: true),
     SingleActivator(LogicalKeyboardKey.end, shift: true)
+  ],
+  CodeShortcutType.selectionExtendWordBoundaryForward: [
+    SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true)
+  ],
+  CodeShortcutType.selectionExtendWordBoundaryBackward: [
+    SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, alt: true)
   ],
   CodeShortcutType.indent: [
     SingleActivator(LogicalKeyboardKey.tab)
@@ -499,6 +514,12 @@ const Map<CodeShortcutType, List<ShortcutActivator>> _kDefaultCommonCodeShortcut
   ],
   CodeShortcutType.selectionExtendLineEnd: [
     SingleActivator(LogicalKeyboardKey.end, shift: true)
+  ],
+  CodeShortcutType.selectionExtendWordBoundaryForward: [
+    SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true)
+  ],
+  CodeShortcutType.selectionExtendWordBoundaryBackward: [
+    SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, alt: true)
   ],
   CodeShortcutType.indent: [
     SingleActivator(LogicalKeyboardKey.tab)


### PR DESCRIPTION
Added moveCursorToWordBoundary and extendSelectionToWordBoundary (forward and selection).

Shortcut keys:
- Move cursor to word boundary (Alt + ←/→)
- Extend selection to word boundary (Shift + Alt + ←/→)

This is an example:

https://github.com/reqable/re-editor/assets/75752751/ebc376fa-4ef7-4fcc-9b0b-16b5707b0daa

