### PR TITLE
Add borderRadius and clipBehavior properties to editor settings

### DIFF
--- a/lib/src/_code_editable.dart
+++ b/lib/src/_code_editable.dart
@@ -26,6 +26,8 @@ class _CodeEditable extends StatefulWidget {
   final EdgeInsetsGeometry margin;
   final Widget? sperator;
   final Border? border;
+  final BorderRadius? borderRadius;
+  final Clip clipBehavior;
   final ValueChanged<CodeLineEditingValue>? onChanged;
   final FocusNode focusNode;
   final CodeLineEditingController controller;
@@ -61,6 +63,8 @@ class _CodeEditable extends StatefulWidget {
     required this.margin,
     required this.sperator,
     this.border,
+    this.borderRadius,
+    this.clipBehavior = Clip.none,
     this.onChanged,
     required this.focusNode,
     required this.controller,
@@ -218,7 +222,9 @@ class _CodeEditableState extends State<_CodeEditable> with AutomaticKeepAliveCli
           decoration: BoxDecoration(
             border: widget.border,
             color: widget.backgroundColor,
+            borderRadius: widget.borderRadius,
           ),
+          clipBehavior: widget.clipBehavior,
           margin: widget.margin,
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/code_editor.dart
+++ b/lib/src/code_editor.dart
@@ -174,6 +174,8 @@ class CodeEditor extends StatefulWidget {
     this.shortcutOverrideActions,
     this.sperator,
     this.border,
+    this.borderRadius,
+    this.clipBehavior = Clip.none,
     this.readOnly,
     this.showCursorWhenReadOnly,
     this.wordWrap,
@@ -236,6 +238,17 @@ class CodeEditor extends StatefulWidget {
 
   /// The border of the editor.
   final Border? border;
+
+  /// The radius of the editor's border corners.
+  ///
+  /// This defines how rounded the corners of the editor's border will appear.
+  ///
+  /// If null, the corners will not be rounded.
+  final BorderRadius? borderRadius;
+
+
+  /// How the content should be clipped if it overflows the editor's bounds.
+  final Clip clipBehavior;
 
   /// Whether the text can be changed.
   ///
@@ -460,6 +473,8 @@ class _CodeEditorState extends State<CodeEditor> {
       showCursorWhenReadOnly: widget.showCursorWhenReadOnly ?? true,
       sperator: widget.sperator,
       border: widget.border,
+      borderRadius: widget.borderRadius,
+      clipBehavior: widget.clipBehavior,
       onChanged: widget.onChanged,
       focusNode: _focusNode,
       padding: (widget.padding ?? _kDefaultPadding).add(EdgeInsets.only(


### PR DESCRIPTION
### Add borderRadius and clipBehavior to Editor Settings

- borderRadius: Customize editor corner radius for better UI design.
- clipBehavior: Control how content overflow is handled (e.g., no clipping, hard edge).

These properties enhance styling flexibility and content management. Without clipBehavior, setting borderRadius may lead to content overflowing out of the widget, resulting in a poor visual experience.
