### PR TITLE
Change autocomplete behavior to replace user input with complete match to support more pattern match method.

### DIFF
--- a/lib/src/_code_editable.dart
+++ b/lib/src/_code_editable.dart
@@ -413,7 +413,9 @@ class _CodeEditableState extends State<_CodeEditable> with AutomaticKeepAliveCli
       onAutocomplete: (value) {
         autocompleteState.dismiss();
         final CodeLineSelection selection = widget.controller.selection;
-        widget.controller.replaceSelection(value.text);
+        widget.controller.replaceSelection(value.word, selection.copyWith(
+          baseOffset: selection.baseOffset - value.input.length,
+        ));
         widget.controller.selection = selection.copyWith(
           baseOffset: selection.baseOffset + value.selection.baseOffset,
           extentOffset: selection.extentOffset + value.selection.extentOffset,

--- a/lib/src/code_autocomplete.dart
+++ b/lib/src/code_autocomplete.dart
@@ -144,23 +144,26 @@ class CodeFunctionPrompt extends CodePrompt {
 class CodeAutocompleteResult {
 
   const CodeAutocompleteResult({
-    required this.text,
+    required this.input,
+    required this.word,
     required this.selection
   });
 
-  factory CodeAutocompleteResult.fromText(String text) {
+  factory CodeAutocompleteResult.fromText(String word) {
     return CodeAutocompleteResult(
-      text: text,
+      input: '',
+      word: word,
       selection: TextSelection.collapsed(
-        offset: text.length
+        offset: word.length
       )
     );
   }
 
   /// The autocomplete text.
   /// e.g.
-  /// If user inputs `go` and the text is `good`, we will replace `go` with `good`.
-  final String text;
+  /// If user inputs `go` and the word is `good`, we will replace `go` with `good`.
+  final String input;
+  final String word;
 
   /// The new selection after the autocompletion.
   final TextSelection selection;
@@ -199,16 +202,16 @@ class CodeAutocompleteEditingValue {
 
   CodeAutocompleteResult get autocomplete {
     final CodeAutocompleteResult result = prompts[index].autocomplete;
-    if (result.text.isEmpty) {
+    if (result.word.isEmpty) {
       return result;
     }
-    final String finalText = result.text.substring(input.length);
     final TextSelection finalSelection = result.selection.copyWith(
       baseOffset: result.selection.baseOffset - input.length,
       extentOffset: result.selection.extentOffset - input.length,
     );
     return CodeAutocompleteResult(
-      text: finalText,
+      input: input,
+      word: result.word,
       selection: finalSelection,
     );
   }


### PR DESCRIPTION
Current autocomplete behavior uses append, which restricts us to case-sensitive prefix matching.
Changing appending to replacing allows us to implement any matching method we want.
For example:  
```dart
class CodeAsmPrompt extends CodePrompt {
//...
@override
  bool match(String input) {
    // Modify this to use case-insensitive subsequence matching.
    return word != input && isSubsequence(word.toLowerCase(), input.toLowerCase());
  }
//...
}
```
We can also combine prefix matching and subsequence matching, similar to how VS Code does it.  

**I may have overlooked some boundary conditions; please review and let me know if there are any.**

Another off-topic question: Can we expose _DefaultCodeAutocompleteListView to users? I think this ListView is good enough for users to just use it. Implementing my own ListView would require a lot of code to copy and paste.