### PR TITLE
Change autocomplete matching and highlight to fuzzy matching

### DIFF
--- a/example/lib/editor_autocomplete.dart
+++ b/example/lib/editor_autocomplete.dart
@@ -339,7 +339,7 @@ extension _TextStyleExtension on TextStyle {
     int valueIndex = 0;
 
     // match first anchor character
-    if (anchor[0] != value[0]) {
+    if (anchor[0].toLowerCase() != value[0].toLowerCase()) {
       for (; valueIndex < value.length; ++valueIndex) {
         if (value[valueIndex] == anchor[0].toUpperCase()) {
           break;

--- a/lib/src/code_autocomplete.dart
+++ b/lib/src/code_autocomplete.dart
@@ -26,7 +26,7 @@ abstract class CodePrompt {
     int wordIndex = 0;
 
     // match first input character
-    if (input[0] != word[0]) {
+    if (input[0].toLowerCase() != word[0].toLowerCase()) {
       for (; wordIndex < word.length; ++wordIndex) {
         if (word[wordIndex] == input[0].toUpperCase()) {
           break;

--- a/lib/src/code_autocomplete.dart
+++ b/lib/src/code_autocomplete.dart
@@ -21,8 +21,37 @@ abstract class CodePrompt {
   CodeAutocompleteResult get autocomplete;
 
   /// Check whether the input meets this prompt condition.
-  bool match(String input);
+  bool match(String input) {
+    int inputIndex = 0;
+    int wordIndex = 0;
 
+    // match first input character
+    if (input[0] != word[0]) {
+      for (; wordIndex < word.length; ++wordIndex) {
+        if (word[wordIndex] == input[0].toUpperCase()) {
+          break;
+        }
+      }
+    }
+    if (wordIndex >= word.length) {
+      return false;
+    }
+    ++inputIndex;
+    ++wordIndex;
+
+    // match subsequence
+    final lowercaseInput = input.toLowerCase();
+    for (; wordIndex < word.length; ++wordIndex) {
+      if (inputIndex >= input.length) {
+        return true;
+      }
+      final char = word[wordIndex].toLowerCase();
+      if (char == lowercaseInput[inputIndex]) {
+        ++inputIndex;
+      }
+    }
+    return inputIndex >= input.length;
+  }
 }
 
 /// The keyword autocomplate prompt. such as 'return', 'class', 'new' and so on.
@@ -34,11 +63,6 @@ class CodeKeywordPrompt extends CodePrompt {
 
   @override
   CodeAutocompleteResult get autocomplete => CodeAutocompleteResult.fromWord(word);
-
-  @override
-  bool match(String input) {
-    return word != input && word.startsWith(input);
-  }
 
   @override
   bool operator ==(Object other) {
@@ -73,11 +97,6 @@ class CodeFieldPrompt extends CodePrompt {
 
   @override
   CodeAutocompleteResult get autocomplete => customAutocomplete ?? CodeAutocompleteResult.fromWord(word);
-
-  @override
-  bool match(String input) {
-    return word != input && word.startsWith(input);
-  }
 
   @override
   bool operator ==(Object other) {
@@ -118,11 +137,6 @@ class CodeFunctionPrompt extends CodePrompt {
 
   @override
   CodeAutocompleteResult get autocomplete => customAutocomplete ?? CodeAutocompleteResult.fromWord('$word(${parameters.keys.join(', ')})');
-
-  @override
-  bool match(String input) {
-    return word != input && word.startsWith(input);
-  }
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
There is one problem: when we type `sink`, the highlight result will be `S`tr`in`gSin`k`.
This issue only involves the highlight behavior, and there’s no problem with the autocomplete result.
I believe this problem falls under the match quality area. Maybe we should solve it when implementing other features related to match quality, such as result sorting, syntax analysis, or providing interfaces to integrate with existing code analyzers.