### PR TITLE
Feat: Enhance autocomplete, support case-insensitive

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -66,18 +66,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.6.0"
   re_highlight:
     dependency: "direct main"
     description:
@@ -122,14 +122,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.3.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/_code_autocomplete.dart
+++ b/lib/src/_code_autocomplete.dart
@@ -132,6 +132,8 @@ class _CodeAutocompleteState extends State<_CodeAutocomplete> {
 
   late final _CodeAutocompleteNavigateAction _navigateAction;
   late final _CodeAutocompleteAction _selectAction;
+  late final _CodeAutocompleteVisibleAction _visibleAction;
+  
 
   ValueChanged<CodeAutocompleteResult>? _onAutocomplete;
   OverlayEntry? _overlayEntry;
@@ -173,6 +175,12 @@ class _CodeAutocompleteState extends State<_CodeAutocomplete> {
         return intent;
       },
     );
+    _visibleAction = _CodeAutocompleteVisibleAction<CodeShortcutEscIntent>(
+      onInvoke: (intent) {
+        dismiss();
+        return intent;
+      },
+    );
   }
 
   @override
@@ -186,6 +194,7 @@ class _CodeAutocompleteState extends State<_CodeAutocomplete> {
       actions: {
         CodeShortcutCursorMoveIntent: _navigateAction,
         CodeShortcutNewLineIntent: _selectAction,
+        CodeShortcutEscIntent: _visibleAction,
       },
       child: widget.child
     );
@@ -285,6 +294,23 @@ class _CodeAutocompleteAction<T extends Intent> extends CallbackAction<T> {
   @override
   bool get isActionEnabled => _isEnabled;
 
+}
+
+class _CodeAutocompleteVisibleAction<T extends Intent> extends CallbackAction<T> {
+  
+  bool _isEnabled = true;
+  
+  _CodeAutocompleteVisibleAction({
+    required super.onInvoke
+  });
+  
+  void setEnabled(bool enabled) {
+    _isEnabled = enabled;
+  }
+  
+  @override
+  bool get isActionEnabled => _isEnabled;
+  
 }
 
 class _CodeAutocompleteNavigateAction extends _CodeAutocompleteAction<CodeShortcutCursorMoveIntent> {

--- a/lib/src/_code_shortcuts.dart
+++ b/lib/src/_code_shortcuts.dart
@@ -99,6 +99,7 @@ class _CodeShortcutActions extends StatelessWidget {
         actions[intent.runtimeType] = _EscCallbackAction(
           controller: editingController,
           findController: findController,
+          context: context,
           onInvoke: (intent) {
             return _onAction(context, intent);
           },
@@ -352,16 +353,19 @@ class _EscCallbackAction<T extends Intent> extends CallbackAction<T> {
 
   final CodeLineEditingController controller;
   final CodeFindController? findController;
+  final BuildContext? context;
 
   _EscCallbackAction({
     required this.controller,
     required this.findController,
     required super.onInvoke,
+    this.context,
   });
 
   @override
   bool isEnabled(T intent) {
-    return !controller.isComposing && (findController?.value != null || !controller.selection.isCollapsed);
+    final _CodeAutocompleteState? autocompleteState = context?.findAncestorStateOfType<_CodeAutocompleteState>();
+    return !controller.isComposing && (findController?.value != null || !controller.selection.isCollapsed || autocompleteState != null);
   }
 
 }

--- a/lib/src/code_autocomplete.dart
+++ b/lib/src/code_autocomplete.dart
@@ -30,7 +30,12 @@ abstract class CodePrompt {
   CodeAutocompleteResult get autocomplete;
 
   /// Check whether the input meets this prompt condition.
-  bool match(String input);
+  bool match(String input) {
+    return word != input &&
+        (caseSensitive
+            ? word.startsWith(input)
+            : word.toLowerCase().startsWith(input.toLowerCase()));
+  }
 
 }
 
@@ -44,14 +49,6 @@ class CodeKeywordPrompt extends CodePrompt {
 
   @override
   CodeAutocompleteResult get autocomplete => CodeAutocompleteResult.fromWord(word);
-
-  @override
-  bool match(String input) {
-    return word != input &&
-            (caseSensitive
-                ? word.startsWith(input)
-                : word.toLowerCase().startsWith(input.toLowerCase()));
-  }
 
   @override
   bool operator ==(Object other) {
@@ -75,6 +72,7 @@ class CodeFieldPrompt extends CodePrompt {
   const CodeFieldPrompt({
     required super.word,
     required this.type,
+    super.caseSensitive = true,
     this.customAutocomplete,
   });
 
@@ -86,11 +84,6 @@ class CodeFieldPrompt extends CodePrompt {
 
   @override
   CodeAutocompleteResult get autocomplete => customAutocomplete ?? CodeAutocompleteResult.fromWord(word);
-
-  @override
-  bool match(String input) {
-    return word != input && word.startsWith(input);
-  }
 
   @override
   bool operator ==(Object other) {
@@ -111,6 +104,7 @@ class CodeFunctionPrompt extends CodePrompt {
 
   const CodeFunctionPrompt({
     required super.word,
+    super.caseSensitive = true,
     required this.type,
     this.parameters = const {},
     this.optionalParameters = const {},
@@ -131,11 +125,6 @@ class CodeFunctionPrompt extends CodePrompt {
 
   @override
   CodeAutocompleteResult get autocomplete => customAutocomplete ?? CodeAutocompleteResult.fromWord('$word(${parameters.keys.join(', ')})');
-
-  @override
-  bool match(String input) {
-    return word != input && word.startsWith(input);
-  }
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/code_autocomplete.dart
+++ b/lib/src/code_autocomplete.dart
@@ -6,8 +6,17 @@ part of re_editor;
 abstract class CodePrompt {
 
   const CodePrompt({
-    required this.word
+    required this.word,
+    this.caseSensitive = true,
   });
+  
+  /// Whether the prompt is case sensitive.
+  /// 
+  /// e.g. 
+  ///    - when false, user input is 'str', the prompt word 'String' will be displayed to user.
+  ///    - when true, user input is 'str', the prompt word 'String' will not be displayed to user.
+  /// default to true
+  final bool caseSensitive;
 
   /// Content associated with user input.
   ///
@@ -29,7 +38,8 @@ abstract class CodePrompt {
 class CodeKeywordPrompt extends CodePrompt {
 
   const CodeKeywordPrompt({
-    required super.word
+    required super.word,
+    super.caseSensitive = true,
   });
 
   @override
@@ -37,7 +47,10 @@ class CodeKeywordPrompt extends CodePrompt {
 
   @override
   bool match(String input) {
-    return word != input && word.startsWith(input);
+    return word != input &&
+            (caseSensitive
+                ? word.startsWith(input)
+                : word.toLowerCase().startsWith(input.toLowerCase()));
   }
 
   @override
@@ -201,7 +214,8 @@ class CodeAutocompleteEditingValue {
   }
 
   CodeAutocompleteResult get autocomplete {
-    final CodeAutocompleteResult result = prompts[index].autocomplete;
+    final selectedPrompt = prompts[index];
+    final CodeAutocompleteResult result = selectedPrompt.autocomplete;
     if (result.word.isEmpty) {
       return result;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  re_highlight: ^0.0.3
+  re_highlight:
+    git:
+      url: https://github.com/CorvusYe/antlr-highlight
+      ref: a64b1162a5765f184a12d4bbb004137b7be50fe4
   isolate_manager: ^4.1.5+1
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  re_highlight:
-    git:
-      url: https://github.com/CorvusYe/antlr-highlight
-      ref: a64b1162a5765f184a12d4bbb004137b7be50fe4
+  re_highlight: ^0.0.3
   isolate_manager: ^4.1.5+1
 
 dev_dependencies:


### PR DESCRIPTION
Sometimes we may not remember the case of keywords accurately, 
so we hope to add a setting in the prompt that can ignore case.

```dart
CodeKeywordPrompt({
    word: 'String',
    caseSensitive: false,
)
```

If that, users can receive a prompt for `String` when entering `str`.


Also, can the `dart format .` command be executed on the entire system to ensure that different people can work in the same coding style environment.