### PR TITLE
Allow custom span cursors

### DIFF
--- a/lib/src/_code_field.dart
+++ b/lib/src/_code_field.dart
@@ -843,6 +843,10 @@ class _CodeFieldRender extends RenderBox implements MouseTrackerAnnotation {
       result.add(BoxHitTestEntry(this, position));
       final CodeLineRenderParagraph? paragraph = _findDisplayRenderParagraph(position + paintOffset);
       final InlineSpan? span = paragraph?.getSpanForPosition(position - paragraph.offset + paintOffset);
+      MouseCursor? spanCursor;
+      if (span is TextSpan && span.cursor != MouseCursor.defer) {
+        spanCursor = span.cursor;
+      }
       if (span is MouseTrackerAnnotationTextSpan) {
         result.add(HitTestEntry(_MouseTrackerAnnotationTextSpan(
           id: paragraph!.index,
@@ -857,7 +861,7 @@ class _CodeFieldRender extends RenderBox implements MouseTrackerAnnotation {
       if (_chunkIndicators.where((chunk) => chunk.canExpand && chunk.region.contains(position)).isNotEmpty) {
         _cursor = SystemMouseCursors.click;
       } else {
-        _cursor = SystemMouseCursors.text;
+        _cursor = spanCursor ?? SystemMouseCursors.text;
       }
       hitTarget = true;
     }


### PR DESCRIPTION
Just a small change to allow specifying a `MouseCursor` when supplying your own `TextSpan` to the `CodeLineEditingController` `spanBuilder`. Useful for adding clickable links.
Quick example:
```dart
  final CodeLineEditingController _codeLineEditingController = CodeLineEditingController(spanBuilder: ({
    required BuildContext context,
    required int index,
    required CodeLine codeLine,
    required TextSpan textSpan,
    required TextStyle style,
  }) {
    return TextSpan(
      children: textSpan.children,
      style: style.copyWith(
        color: Colors.blueAccent,
        decoration: TextDecoration.underline,
      ),
      mouseCursor: SystemMouseCursors.click, // This was previously ignored!
      recognizer: (TapGestureRecognizer()..onTap = () {
        // handle taps
      }),
    ); 
  });
  ```