### PR TITLE
Disable autocorrection and smart text features in code editor

### DIFF
--- a/lib/src/_code_input.dart
+++ b/lib/src/_code_input.dart
@@ -441,7 +441,11 @@ class _CodeInputController extends ChangeNotifier implements DeltaTextInputClien
         _TextInputConfiguration(
           flutterViewId: View.maybeOf(context)?.viewId ?? 0,
           enableDeltaModel: true,
-          inputAction: TextInputAction.newline
+          inputAction: TextInputAction.newline,
+          autocorrect: false,
+          smartDashesType: SmartDashesType.disabled,
+          smartQuotesType: SmartQuotesType.disabled,
+          textCapitalization: TextCapitalization.none,
         ),
       );
       _remoteEditingValue = _buildTextEditingValue();
@@ -731,6 +735,10 @@ class _TextInputConfiguration extends TextInputConfiguration {
     required this.flutterViewId,
     required super.enableDeltaModel,
     required super.inputAction,
+    super.autocorrect = false,
+    super.smartDashesType = SmartDashesType.disabled,
+    super.smartQuotesType = SmartQuotesType.disabled,
+    super.textCapitalization = TextCapitalization.none,
   });
 
   @override


### PR DESCRIPTION
This PR disables unwanted text transformations in the code editor by configuring the `TextInputConfiguration` to turn off autocorrection and smart text features.

I'm using this editor in [PG Orbit](https://pgorbit.com) a postgresql client and when typing `id` on iOS it would autocorrect to `I'd`