### PR TITLE
Fix stale CodeEditor findController listener swap

### DIFF
--- a/lib/src/code_editor.dart
+++ b/lib/src/code_editor.dart
@@ -460,11 +460,13 @@ class _CodeEditorState extends State<CodeEditor> {
       _editingController.bindEditor(_editorKey);
     }
     if (oldWidget.findController != widget.findController || oldWidget.controller != widget.controller) {
+      final CodeFindController oldFindController = _findController;
       if (oldWidget.findController == null) {
-        _findController.dispose();
+        oldFindController.dispose();
+      } else {
+        oldFindController.removeListener(_updateWidget);
       }
       _findController = widget.findController ?? CodeFindController(_editingController);
-      _findController.removeListener(_updateWidget);
       _findController.addListener(_updateWidget);
     }
     if (oldWidget.scrollController != widget.scrollController) {

--- a/test/code_search_controller_test.dart
+++ b/test/code_search_controller_test.dart
@@ -886,4 +886,68 @@ void main() {
       }
     });
   });
+
+  group('CodeEditor ', () {
+    testWidgets('ignores notifications from a previous findController after swap', (tester) async {
+      final CodeLineEditingController editingController = CodeLineEditingController.fromText('abc');
+      final CodeFindController oldFindController = CodeFindController(editingController);
+      final CodeFindController newFindController = CodeFindController(editingController);
+      int buildCount = 0;
+      CodeFindController? lastBuiltController;
+
+      PreferredSizeWidget buildFindWidget(
+        BuildContext context,
+        CodeFindController controller,
+        bool readonly,
+      ) {
+        buildCount++;
+        lastBuiltController = controller;
+        return const PreferredSize(
+          preferredSize: Size.zero,
+          child: SizedBox.shrink(),
+        );
+      }
+
+      await tester.pumpWidget(MaterialApp(
+        home: CodeEditor(
+          controller: editingController,
+          findController: oldFindController,
+          findBuilder: buildFindWidget,
+          autofocus: false,
+        ),
+      ));
+
+      expect(lastBuiltController, same(oldFindController));
+
+      await tester.pumpWidget(MaterialApp(
+        home: CodeEditor(
+          controller: editingController,
+          findController: newFindController,
+          findBuilder: buildFindWidget,
+          autofocus: false,
+        ),
+      ));
+
+      expect(lastBuiltController, same(newFindController));
+      final int buildCountAfterSwap = buildCount;
+
+      oldFindController.findMode();
+      await tester.pump();
+
+      expect(buildCount, buildCountAfterSwap);
+      expect(lastBuiltController, same(newFindController));
+
+      newFindController.findMode();
+      await tester.pump();
+
+      expect(buildCount, greaterThan(buildCountAfterSwap));
+      expect(lastBuiltController, same(newFindController));
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+      oldFindController.dispose();
+      newFindController.dispose();
+      editingController.dispose();
+    });
+  });
 }

--- a/test/code_search_controller_test.dart
+++ b/test/code_search_controller_test.dart
@@ -949,5 +949,38 @@ void main() {
       newFindController.dispose();
       editingController.dispose();
     });
+
+    testWidgets('ignores stale findController notifications after the editor is removed', (tester) async {
+      final CodeLineEditingController editingController = CodeLineEditingController.fromText('abc');
+      final CodeFindController oldFindController = CodeFindController(editingController);
+      final CodeFindController newFindController = CodeFindController(editingController);
+
+      await tester.pumpWidget(MaterialApp(
+        home: CodeEditor(
+          controller: editingController,
+          findController: oldFindController,
+          autofocus: false,
+        ),
+      ));
+
+      await tester.pumpWidget(MaterialApp(
+        home: CodeEditor(
+          controller: editingController,
+          findController: newFindController,
+          autofocus: false,
+        ),
+      ));
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+      oldFindController.findMode();
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+
+      oldFindController.dispose();
+      newFindController.dispose();
+      editingController.dispose();
+    });
   });
 }


### PR DESCRIPTION
## Summary
- remove `_updateWidget` from the previous `findController` before swapping controllers in `CodeEditor.didUpdateWidget`
- add regression tests for stale notifications after a controller swap and after the editor is removed

## Problem
When `CodeEditor` swaps to a new `findController`, `didUpdateWidget()` overwrites `_findController` before removing `_updateWidget`. That means the remove call targets the new controller instead of the old one, leaving the old controller able to keep rebuilding the editor after it has been detached.

## Reproduction
1. Build a `CodeEditor` with `oldFindController`
2. Rebuild it with `newFindController`
3. Trigger `oldFindController.findMode()`

Before this change, the stale controller still notifies the editor and causes an extra rebuild. If the editor is removed from the tree first, the stale controller can also trigger `setState()` after dispose.

## Fix
Store the previous controller in a local variable, detach `_updateWidget` from that instance, then assign and subscribe the new controller.

## Verification
- red step: reverted the production fix, each regression test failed
- green step: restored the fix, both regression tests passed
- `flutter test test/code_search_controller_test.dart`
- `flutter analyze --no-fatal-infos lib/src/code_editor.dart test/code_search_controller_test.dart`

## Bug origin
- introduced in `b35627f` on 2024-02-05

## Follow-up improvements in this PR
- closes #108
