### PR TITLE
fix: guard delayed drag autoscroll after dispose

### DIFF
--- a/lib/src/_code_selection.dart
+++ b/lib/src/_code_selection.dart
@@ -375,11 +375,19 @@ class _CodeSelectionGestureDetectorState extends State<_CodeSelectionGestureDete
   void _autoScrollWhenDragging() {
     final Offset? position = _dragPosition;
     Future.delayed(const Duration(milliseconds: 100), (() {
+      // Widget may have been disposed while the delayed callback was pending.
+      if (!mounted) {
+        return;
+      }
       if (_dragPosition == null || position == null) {
         return;
       }
       if (_dragging) {
-        render.autoScrollWhenDragging(_dragPosition!);
+        final renderObject = widget.editorKey.currentContext?.findRenderObject();
+        if (renderObject is! _CodeFieldRender) {
+          return;
+        }
+        renderObject.autoScrollWhenDragging(_dragPosition!);
         _extendSelection(_dragPosition!, _SelectionChangedCause.drag);
       }
       _autoScrollWhenDragging();
@@ -909,7 +917,12 @@ class _MobileSelectionOverlayController implements _SelectionOverlayController {
       if (!_startHandleDragging) {
         return;
       }
-      ensureRender.autoScrollWhenDragging(_startHandleDragLastPosition);
+      // Overlay/controller may outlive the field after dispose.
+      final renderObject = editorKey.currentContext?.findRenderObject();
+      if (renderObject is! _CodeFieldRender) {
+        return;
+      }
+      renderObject.autoScrollWhenDragging(_startHandleDragLastPosition);
       _handleStartHandleDragUpdate(_startHandleDragLastPosition);
       _autoScrollWhenStartHandleDragging();
     }));
@@ -920,7 +933,11 @@ class _MobileSelectionOverlayController implements _SelectionOverlayController {
       if (!_endHandleDragging) {
         return;
       }
-      ensureRender.autoScrollWhenDragging(_endHandleDragLastPosition);
+      final renderObject = editorKey.currentContext?.findRenderObject();
+      if (renderObject is! _CodeFieldRender) {
+        return;
+      }
+      renderObject.autoScrollWhenDragging(_endHandleDragLastPosition);
       _handleEndHandleDragUpdate(_endHandleDragLastPosition);
       _autoScrollWhenEndHandleDragging();
     }));


### PR DESCRIPTION
## Summary

Delayed drag autoscroll callbacks can run after the `CodeEditor` is disposed. They call `render` / `ensureRender`, which cast `findRenderObject()` with `as _CodeFieldRender`. When `currentContext` is null after dispose, that cast throws and crashes the app.

This change:
- Returns early when `!mounted` in the gesture detector autoscroll loop
- Uses a safe `is! _CodeFieldRender` check instead of a force cast before calling `autoScrollWhenDragging` (desktop drag + mobile handle drag paths)

## Failure scenario

1. User starts a text selection drag (or drags a mobile selection handle).
2. Autoscroll schedules `Future.delayed(100ms, ...)`.
3. The editor is removed from the tree before the callback runs.
4. The callback dereferences a null render object via `as _CodeFieldRender` and crashes.

## Bug origin

`_autoScrollWhenDragging` has used `Future.delayed` since the selection gesture code was introduced (MegatronKing, 2024-02). The mobile handle paths use the same pattern with `ensureRender`.

## Related

- Audit finding F004 (dispose-time cast crash on delayed autoscroll)
- Prior merged fix for a related dispose/listener issue: #107

## Test plan

- [x] Diff limited to the three delayed autoscroll callbacks
- [ ] Manual: start drag selection, dispose the editor mid-drag, confirm no crash
- [ ] CI analysis on the package

No automated widget test added: this path depends on Flutter render objects and delayed callbacks; the fix is the same null-safe pattern already used elsewhere in `_MobileSelectionOverlayController` for optional render lookups.
