### PR TITLE
Implement moveCursorToPageUp/Down and bind PageUp/PageDown to them

### DIFF
--- a/lib/src/_code_line.dart
+++ b/lib/src/_code_line.dart
@@ -485,12 +485,38 @@ class _CodeLineEditingControllerImpl extends ValueNotifier<CodeLineEditingValue>
 
   @override
   void moveCursorToPageUp() {
-    // TODO
+    _moveCursorByPage(false);
   }
 
   @override
   void moveCursorToPageDown() {
-    // TODO
+    _moveCursorByPage(true);
+  }
+
+  /// Moves the cursor a screen up or down.
+  ///
+  /// The page is measured from the viewport: as many lines as fit on screen,
+  /// less one kept as an overlap so that the reader can connect what was on
+  /// screen with what is there now. With word wrap on, a wrapped line still
+  /// counts as one, so the jump may be longer than a screen.
+  void _moveCursorByPage(bool forward) {
+    final _CodeFieldRender? render = _render;
+    if (render == null || !render.hasSize || render.lineHeight <= 0) {
+      // Nothing is laid out yet, so there is no page to measure. Moving by a
+      // single line is still better than standing still.
+      moveCursor(forward ? AxisDirection.down : AxisDirection.up);
+      return;
+    }
+
+    final int page = max(1, (render.size.height / render.lineHeight).floor() - 1);
+    final CodeLinePosition current = selection.extent;
+    final int index = min(max(0, current.index + (forward ? page : -page)), codeLines.length - 1);
+
+    selection = CodeLineSelection.collapsed(
+      index: index,
+      offset: min(codeLines[index].length, current.offset)
+    );
+    makeCursorVisible();
   }
 
   @override

--- a/lib/src/code_shortcuts.dart
+++ b/lib/src/code_shortcuts.dart
@@ -345,6 +345,12 @@ const Map<CodeShortcutType, List<ShortcutActivator>> _kDefaultMacCodeShortcutsAc
     SingleActivator(LogicalKeyboardKey.arrowDown, meta: true),
     SingleActivator(LogicalKeyboardKey.end, control: true)
   ],
+  CodeShortcutType.cursorMovePageUp: [
+    SingleActivator(LogicalKeyboardKey.pageUp)
+  ],
+  CodeShortcutType.cursorMovePageDown: [
+    SingleActivator(LogicalKeyboardKey.pageDown)
+  ],
   CodeShortcutType.cursorMoveWordBoundaryBackward: [
     SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true)
   ],
@@ -534,6 +540,12 @@ const Map<CodeShortcutType, List<ShortcutActivator>> _kDefaultCommonCodeShortcut
     SingleActivator(LogicalKeyboardKey.end, control: true),
   // NumLockedSingleActivator(LogicalKeyboardKey.numpad1, shift: true, control: true),
   // NumUnlockedSingleActivator(LogicalKeyboardKey.numpad1, control: true),
+  ],
+  CodeShortcutType.cursorMovePageUp: [
+    SingleActivator(LogicalKeyboardKey.pageUp),
+  ],
+  CodeShortcutType.cursorMovePageDown: [
+    SingleActivator(LogicalKeyboardKey.pageDown),
   ],
   CodeShortcutType.cursorMoveWordBoundaryBackward: [
     SingleActivator(LogicalKeyboardKey.arrowLeft, control: true),


### PR DESCRIPTION
## What this fixes

`moveCursorToPageUp` and `moveCursorToPageDown` are empty stubs marked
`// TODO`, and neither `PageUp` nor `PageDown` is bound to anything in the
default activators — on any platform. Pressing either key does nothing at all.

## The change

* Both methods are implemented. The page is measured from the viewport: as many
  lines as fit on screen, less one kept as an overlap so that the reader can
  connect what was on screen with what is there now.
* When nothing is laid out yet there is no page to measure, so the cursor moves
  by a single line rather than standing still.
* `PageUp` and `PageDown` are added to both default activator maps, next to the
  existing `cursorMovePageStart` / `cursorMovePageEnd` bindings.

## Notes

With word wrap on, a wrapped line still counts as one, so the jump may be longer
than a screen. Moving by visual lines would need the target line to be laid out,
and it is not once it leaves the viewport — `getDownPosition` returns null there.
Happy to take a different approach if you prefer visual lines.

Found while building a file manager on `re_editor`.

---

Part of a small series from the same project: #122, #123, #125.
