### PR TITLE
Do not fail highlighting when the theme declares no languages

### DIFF
--- a/lib/src/_code_highlight.dart
+++ b/lib/src/_code_highlight.dart
@@ -213,7 +213,12 @@ class _CodeHighlightEngine {
       return;
     }
     final Map<String, CodeHighlightThemeMode>? modes = _theme?.languages;
-    if (modes == null) {
+    // An empty language map means there is nothing to highlight, which is not
+    // a reason to fail. Without this the payload carried empty lists of sizes,
+    // `_run` reduced them, and `Bad state: No element` was thrown inside the
+    // isolate: highlighting died silently and left an unhandled exception in
+    // the console.
+    if (modes == null || modes.isEmpty) {
       callback(const []);
       return;
     }


### PR DESCRIPTION
## What this fixes

`CodeHighlightTheme(languages: {})` is a legitimate thing to build: an editor
showing a file whose language it does not recognise still wants the theme for
its text colours. The payload then carries empty lists of sizes, `_run` reduces
them, and `Bad state: No element` is thrown — **inside the isolate**, so
highlighting dies silently and all that is left is an unhandled exception in the
console.

```
Unhandled Exception: Bad state: No element
#0      ListBase.reduce (dart:collection/list.dart:187:22)
#1      _CodeHighlightEngine._run (package:re_editor/src/_code_highlight.dart:232:42)
```

We hit it opening a `.log` file.

## The change

Nothing to highlight is answered with an empty result, exactly as it already is
when there is no theme at all.

---

Part of a small series from the same project: #122, #123, #124.
